### PR TITLE
feat: add sticky title component

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,5 +1,51 @@
+import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ChecklistFeatureClient as ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { IndentFeatureClient as IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { InlineCodeFeatureClient as InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { SuperscriptFeatureClient as SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { SubscriptFeatureClient as SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
 }

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -1,5 +1,6 @@
 import { HeroBlock } from "@/components/hero/hero.block";
 import { RichTextBlock } from "@/components/richtext/richtext.block";
+import { StickyTitleBlock } from "@/components/sticky-title/sticky-title.block";
 import type { CollectionConfig } from "payload";
 
 export const Pages: CollectionConfig = {
@@ -30,7 +31,7 @@ export const Pages: CollectionConfig = {
 						{
 							name: "blocks",
 							type: "blocks",
-							blocks: [HeroBlock, RichTextBlock],
+							blocks: [HeroBlock, RichTextBlock, StickyTitleBlock],
 						},
 					],
 				},

--- a/src/components/blocks.tsx
+++ b/src/components/blocks.tsx
@@ -1,15 +1,24 @@
-import type { HeroBlockType, RichTextBlock } from "@/payload-types";
+import type {
+	HeroBlockType,
+	RichTextBlock,
+	StickyTitleBlock,
+} from "@/payload-types";
 import type { ComponentType } from "react";
 import { Hero } from "./hero/hero";
 import { RichText } from "./richtext/richtext";
+import { StickyTitle } from "./sticky-title/sticky-title";
 
 interface BlocksProps {
-	blocks: (RichTextBlock | HeroBlockType)[] | null | undefined;
+	blocks:
+		| (RichTextBlock | HeroBlockType | StickyTitleBlock)[]
+		| null
+		| undefined;
 }
 
 const components = {
 	hero: Hero,
 	"rich-text": RichText,
+	"sticky-title": StickyTitle,
 };
 
 function Blocks({ blocks }: BlocksProps) {

--- a/src/components/sticky-title/sticky-title.block.ts
+++ b/src/components/sticky-title/sticky-title.block.ts
@@ -1,0 +1,36 @@
+import { RichTextBlock } from "@/components/richtext/richtext.block";
+import type { Block } from "payload";
+
+const StickyTitleBlock: Block = {
+	slug: "sticky-title",
+	interfaceName: "StickyTitleBlock",
+	fields: [
+		{
+			type: "tabs",
+			tabs: [
+				{
+					label: "Content",
+					fields: [
+						{
+							name: "title",
+							type: "text",
+							label: "Title",
+							required: true,
+						},
+						{
+							name: "blocks",
+							type: "blocks",
+							blocks: [RichTextBlock],
+						},
+					],
+				},
+				{
+					label: "Settings",
+					fields: [],
+				},
+			],
+		},
+	],
+};
+
+export { StickyTitleBlock };

--- a/src/components/sticky-title/sticky-title.module.css
+++ b/src/components/sticky-title/sticky-title.module.css
@@ -1,0 +1,18 @@
+.container {
+	max-width: var(--container);
+	margin-left: auto;
+	margin-right: auto;
+	padding: 0 var(--space-2xs);
+	display: grid;
+	grid-template-rows: auto auto;
+
+	@media (--viewport-md) {
+		grid-template-columns: 33.33% 1fr;
+	}
+}
+
+.title {
+	position: sticky;
+	top: 0;
+	font-size: var(--font-size-xl);
+}

--- a/src/components/sticky-title/sticky-title.tsx
+++ b/src/components/sticky-title/sticky-title.tsx
@@ -1,6 +1,6 @@
 import { Blocks } from "@/components/blocks";
-import { cva } from "class-variance-authority";
 import type { StickyTitleBlock } from "@/payload-types";
+import { cva } from "class-variance-authority";
 import styles from "./sticky-title.module.css";
 
 const stickyTitleStyles = cva(styles.container);

--- a/src/components/sticky-title/sticky-title.tsx
+++ b/src/components/sticky-title/sticky-title.tsx
@@ -1,0 +1,21 @@
+import { Blocks } from "@/components/blocks";
+import { cva } from "class-variance-authority";
+import type { StickyTitleBlock } from "@/payload-types";
+import styles from "./sticky-title.module.css";
+
+const stickyTitleStyles = cva(styles.container);
+
+function StickyTitle(props: StickyTitleBlock) {
+	return (
+		<section className={stickyTitleStyles()}>
+			<div>
+				<h2 className={styles.title}>{props.title}</h2>
+			</div>
+			<div>
+				<Blocks blocks={props.blocks} />
+			</div>
+		</section>
+	);
+}
+
+export { StickyTitle };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1645,7 +1645,7 @@ export interface Page {
   title: string;
   slug: string;
   content?: {
-    blocks?: (HeroBlockType | RichTextBlock)[] | null;
+    blocks?: (HeroBlockType | RichTextBlock | StickyTitleBlock)[] | null;
   };
   updatedAt: string;
   createdAt: string;
@@ -1704,6 +1704,17 @@ export interface RichTextBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'rich-text';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "StickyTitleBlock".
+ */
+export interface StickyTitleBlock {
+  title: string;
+  blocks?: RichTextBlock[] | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'sticky-title';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1798,6 +1809,7 @@ export interface PagesSelect<T extends boolean = true> {
           | {
               hero?: T | HeroBlockTypeSelect<T>;
               'rich-text'?: T | RichTextBlockSelect<T>;
+              'sticky-title'?: T | StickyTitleBlockSelect<T>;
             };
       };
   updatedAt?: T;
@@ -1820,6 +1832,20 @@ export interface HeroBlockTypeSelect<T extends boolean = true> {
  */
 export interface RichTextBlockSelect<T extends boolean = true> {
   richText?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "StickyTitleBlock_select".
+ */
+export interface StickyTitleBlockSelect<T extends boolean = true> {
+  title?: T;
+  blocks?:
+    | T
+    | {
+        'rich-text'?: T | RichTextBlockSelect<T>;
+      };
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
Introduce a new sticky title component that allows users to create titles that remain fixed at the top of the viewport. This update includes the necessary configurations and styles to support the new component within the existing block structure.

Fixes #30