### PR TITLE
feat: add revalidation hook for Pages and Settings collections

### DIFF
--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -1,6 +1,7 @@
 import { HeroBlock } from "@/components/hero/hero.block";
 import { RichTextBlock } from "@/components/richtext/richtext.block";
 import { StickyTitleBlock } from "@/components/sticky-title/sticky-title.block";
+import { revalidateAfterChange } from "@/util/revalidateAfterChange";
 import type { CollectionConfig } from "payload";
 
 export const Pages: CollectionConfig = {
@@ -38,4 +39,7 @@ export const Pages: CollectionConfig = {
 			],
 		},
 	],
+	hooks: {
+		afterChange: [revalidateAfterChange],
+	},
 };

--- a/src/collections/Settings.ts
+++ b/src/collections/Settings.ts
@@ -1,4 +1,5 @@
 import { iconField } from "@/fields/icon";
+import { revalidateAfterChange } from "@/util/revalidateAfterChange";
 import type { GlobalConfig } from "payload";
 
 export const Settings: GlobalConfig = {
@@ -69,4 +70,7 @@ export const Settings: GlobalConfig = {
 			],
 		},
 	],
+	hooks: {
+		afterChange: [revalidateAfterChange],
+	},
 };

--- a/src/util/revalidateAfterChange.ts
+++ b/src/util/revalidateAfterChange.ts
@@ -1,19 +1,19 @@
 import { revalidatePath } from "next/cache";
 
 function revalidateAfterChange({
-  doc,
-  previousDoc,
+	doc,
+	previousDoc,
 }: {
-  doc: {
-    slug: string;
-    _status: "published" | "draft";
-  };
-  previousDoc: unknown;
+	doc: {
+		slug: string;
+		_status: "published" | "draft";
+	};
+	previousDoc: unknown;
 }) {
-  if (doc.slug && doc._status === "published" && doc !== previousDoc) {
-    console.log("Revalidating...");
-    revalidatePath("/", "layout");
-  }
+	if (doc.slug && doc._status === "published" && doc !== previousDoc) {
+		console.log("Revalidating...");
+		revalidatePath("/", "layout");
+	}
 }
 
 export { revalidateAfterChange };

--- a/src/util/revalidateAfterChange.ts
+++ b/src/util/revalidateAfterChange.ts
@@ -1,0 +1,19 @@
+import { revalidatePath } from "next/cache";
+
+function revalidateAfterChange({
+  doc,
+  previousDoc,
+}: {
+  doc: {
+    slug: string;
+    _status: "published" | "draft";
+  };
+  previousDoc: unknown;
+}) {
+  if (doc.slug && doc._status === "published" && doc !== previousDoc) {
+    console.log("Revalidating...");
+    revalidatePath("/", "layout");
+  }
+}
+
+export { revalidateAfterChange };


### PR DESCRIPTION
Introduce a revalidation hook that triggers after changes in the Pages and Settings collections to ensure the layout is updated accordingly.

fixes #48 