### PR TITLE
feat: integrate SEO plugin and metadata generation for pages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["pnpm-lock.yaml", "payload-types.ts", "src/app/(payload)/**/*"]
+		"ignore": [
+			"pnpm-lock.yaml",
+			"payload-types.ts",
+			"src/app/(payload)/**/*",
+			"node_modules",
+			".next",
+			"media"
+		]
 	},
 	"css": {
 		"linter": {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 import { withPayload } from "@payloadcms/next/withPayload";
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+	reactStrictMode: true,
+};
 
 export default withPayload(nextConfig, { devBundleServerPackages: false });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"@fontsource-variable/national-park": "^5.2.1",
 		"@payloadcms/db-mongodb": "^3.35.1",
 		"@payloadcms/next": "^3.35.1",
+		"@payloadcms/plugin-seo": "^3.35.1",
 		"@payloadcms/richtext-lexical": "^3.35.1",
 		"@payloadcms/storage-s3": "^3.35.1",
 		"@phosphor-icons/core": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@payloadcms/next':
         specifier: ^3.35.1
         version: 3.35.1(@types/react@19.1.0)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      '@payloadcms/plugin-seo':
+        specifier: ^3.35.1
+        version: 3.35.1(@types/react@19.1.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       '@payloadcms/richtext-lexical':
         specifier: ^3.35.1
         version: 3.35.1(@faceless-ui/modal@3.0.0-beta.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@faceless-ui/scroll-info@2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@payloadcms/next@3.35.1(@types/react@19.1.0)(graphql@16.11.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(@types/react@19.1.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)(yjs@13.6.26)
@@ -1175,6 +1178,13 @@ packages:
 
   '@payloadcms/plugin-cloud-storage@3.35.1':
     resolution: {integrity: sha512-F/IPWZMoLftG5lQCp/qyzKWwBbMbE+WOJ+5Zmg8oH9KY8opxgAiK4xxE+GwmVdOCAW6C7yjgjdwGZsNO1WDbGw==}
+    peerDependencies:
+      payload: 3.35.1
+      react: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
+      react-dom: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
+
+  '@payloadcms/plugin-seo@3.35.1':
+    resolution: {integrity: sha512-lbxdBGMetz27NYhk8uJu9pC/gAKGkTTI/PL02S3sJGVJbFDr17T5QCd8d3EVsZ0wqRP8Ep+OCpu+VLYJM0dQDA==}
     peerDependencies:
       payload: 3.35.1
       react: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
@@ -4787,6 +4797,20 @@ snapshots:
       find-node-modules: 2.1.3
       payload: 3.35.1(graphql@16.11.0)(typescript@5.7.3)
       range-parser: 1.2.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - monaco-editor
+      - next
+      - supports-color
+      - typescript
+
+  '@payloadcms/plugin-seo@3.35.1(@types/react@19.1.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)':
+    dependencies:
+      '@payloadcms/translations': 3.35.1
+      '@payloadcms/ui': 3.35.1(@types/react@19.1.0)(monaco-editor@0.52.2)(next@15.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(payload@3.35.1(graphql@16.11.0)(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      payload: 3.35.1(graphql@16.11.0)(typescript@5.7.3)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:

--- a/src/app/(frontend)/(pages)/[slug]/page.template.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.template.tsx
@@ -1,5 +1,6 @@
 import type { Page as PageType } from "@/payload-types";
 import type { ReactElement } from "react";
+import type { Metadata } from "next";
 import { payload } from "@/util/getPayloadConfig";
 import { PageTemplate } from "./page";
 import { generateMeta } from "@/util/generateMetadata";

--- a/src/app/(frontend)/(pages)/[slug]/page.template.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.template.tsx
@@ -2,6 +2,8 @@ import type { Page as PageType } from "@/payload-types";
 import { payload } from "@/util/getPayloadConfig";
 import type { ReactElement } from "react";
 import { PageTemplate } from "./page";
+import { generateMeta } from "@/util/generateMetadata";
+import type { Metadata } from "next";
 
 type Args = {
 	params: Promise<{ slug: string }>;
@@ -70,6 +72,26 @@ export async function generateStaticParams() {
 	} catch (error) {
 		return [];
 	}
+}
+
+export async function generateMetadata({ params }: Args): Promise<Metadata> {
+	const { slug = "home" } = await params;
+	const page = await payload
+		.find({
+			collection: "pages",
+			limit: 1,
+			where: {
+				slug: {
+					equals: slug,
+				},
+			},
+			pagination: false,
+		})
+		.then((res) => res.docs?.[0]);
+
+	if (!page) return {};
+
+	return generateMeta({ doc: page, collection: "pages" });
 }
 
 export default Page;

--- a/src/app/(frontend)/(pages)/[slug]/page.template.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.template.tsx
@@ -1,5 +1,5 @@
 import type { Page as PageType } from "@/payload-types";
-import { generateMeta } from "@/util/generateMetadata";
+import type { ReactElement } from "react";
 import { payload } from "@/util/getPayloadConfig";
 import { PageTemplate } from "./page";
 import { generateMeta } from "@/util/generateMetadata";

--- a/src/app/(frontend)/(pages)/[slug]/page.template.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.template.tsx
@@ -1,9 +1,9 @@
 import type { Page as PageType } from "@/payload-types";
-import { payload } from "@/util/getPayloadConfig";
 import type { ReactElement } from "react";
+import type { Metadata } from "next";
+import { payload } from "@/util/getPayloadConfig";
 import { PageTemplate } from "./page";
 import { generateMeta } from "@/util/generateMetadata";
-import type { Metadata } from "next";
 
 type Args = {
 	params: Promise<{ slug: string }>;

--- a/src/app/(frontend)/(pages)/[slug]/page.template.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.template.tsx
@@ -1,6 +1,5 @@
 import type { Page as PageType } from "@/payload-types";
-import type { ReactElement } from "react";
-import type { Metadata } from "next";
+import { generateMeta } from "@/util/generateMetadata";
 import { payload } from "@/util/getPayloadConfig";
 import { PageTemplate } from "./page";
 import { generateMeta } from "@/util/generateMetadata";

--- a/src/app/(frontend)/(pages)/page.tsx
+++ b/src/app/(frontend)/(pages)/page.tsx
@@ -1,3 +1,5 @@
-import PageTemplate from "./[slug]/page.template";
+import PageTemplate, { generateMetadata } from "./[slug]/page.template";
 
 export default PageTemplate;
+
+export { generateMetadata };

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -21,6 +21,11 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
@@ -47,5 +52,10 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
 }

--- a/src/fields/icon.ts
+++ b/src/fields/icon.ts
@@ -4,16 +4,16 @@ import { type Field, deepMerge } from "payload";
 type IconField = (overrides?: Partial<Field>) => Field;
 
 const iconField: IconField = (overrides = {}) =>
-  deepMerge(
-    {
-      name: "icon",
-      label: "Icon",
-      type: "select",
-      interfaceName: "Icons",
-      options: icons.map((icon) => icon.pascal_name),
-      required: true,
-    },
-    overrides,
-  );
+	deepMerge(
+		{
+			name: "icon",
+			label: "Icon",
+			type: "select",
+			interfaceName: "Icons",
+			options: icons.map((icon) => icon.pascal_name),
+			required: true,
+		},
+		overrides,
+	);
 
 export { iconField };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1655,6 +1655,7 @@ export interface Page {
   content?: {
     blocks?: (HeroBlockType | RichTextBlock | StickyTitleBlock)[] | null;
   };
+  meta?: SeoType;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -1725,6 +1726,18 @@ export interface StickyTitleBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'sticky-title';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SeoType".
+ */
+export interface SeoType {
+  title?: string | null;
+  description?: string | null;
+  /**
+   * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
+   */
+  image?: (string | null) | Media;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1918,6 +1931,7 @@ export interface PagesSelect<T extends boolean = true> {
               'sticky-title'?: T | StickyTitleBlockSelect<T>;
             };
       };
+  meta?: T | SeoTypeSelect<T>;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1955,6 +1969,15 @@ export interface StickyTitleBlockSelect<T extends boolean = true> {
       };
   id?: T;
   blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SeoType_select".
+ */
+export interface SeoTypeSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
+  image?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,6 +10,7 @@ import { Users } from "./collections/Users";
 import { Media } from "./collections/Media";
 import { Settings } from "./collections/Settings";
 import { Pages } from "./collections/Pages";
+import { seoPlugin } from "@payloadcms/plugin-seo";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -37,6 +38,12 @@ export default buildConfig({
 	}),
 	sharp,
 	plugins: [
+		seoPlugin({
+			collections: [Pages.slug],
+			uploadsCollection: Media.slug,
+			tabbedUI: true,
+			interfaceName: "SeoType",
+		}),
 		s3Storage({
 			enabled: process.env.NODE_ENV === "production",
 			collections: {

--- a/src/util/generateMetadata.ts
+++ b/src/util/generateMetadata.ts
@@ -23,7 +23,7 @@ function getImageURL(
 
 async function generateMeta(args: {
 	doc: Partial<Page>;
-	collection: "pages" | "blog";
+	collection: "pages";
 }): Promise<Metadata> {
 	const { doc } = args || {};
 

--- a/src/util/generateMetadata.ts
+++ b/src/util/generateMetadata.ts
@@ -1,0 +1,53 @@
+import type { Config, Media, Page } from "@/payload-types";
+import type { Metadata } from "next";
+import { getServersideURL } from "./getServersideURL";
+import { mergeOpenGraph } from "./mergeMetadata";
+
+function getImageURL(
+	image?: Media | Config["db"]["defaultIDType"] | null,
+): string | undefined {
+	const serverURL = getServersideURL();
+	let url = serverURL;
+
+	if (image && typeof image === "object") {
+		const ogURL = image.url;
+
+		url = ogURL ? serverURL + ogURL : serverURL + url;
+
+		return url;
+	}
+
+	// TODO: Implement default image
+	return undefined;
+}
+
+async function generateMeta(args: {
+	doc: Partial<Page>;
+	collection: "pages" | "blog";
+}): Promise<Metadata> {
+	const { doc } = args || {};
+
+	const ogImage = getImageURL(doc.meta?.image);
+	const title = doc.meta?.title || "";
+	const description = doc.meta?.description || "";
+
+	const slug = doc.slug === "home" ? "" : `/${doc.slug}`;
+	const collection = args.collection === "pages" ? "" : `/${args.collection}`;
+	const url = `${getServersideURL()}${collection}${slug}`;
+
+	return {
+		title,
+		description,
+		openGraph: mergeOpenGraph({
+			title,
+			description,
+			images: ogImage ? [{ url: ogImage }] : [],
+			url,
+		}),
+		alternates: {
+			canonical: url,
+		},
+	};
+}
+
+export { generateMeta };

--- a/src/util/getPayloadConfig.ts
+++ b/src/util/getPayloadConfig.ts
@@ -2,5 +2,5 @@ import config from "@/payload.config";
 import { getPayload } from "payload";
 
 export const payload = await getPayload({
-  config,
+	config,
 });

--- a/src/util/mergeMetadata.ts
+++ b/src/util/mergeMetadata.ts
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+const defaultOpenGraph: Metadata["openGraph"] = {
+  type: "website",
+  // TODO: Add defaults
+};
+
+function mergeOpenGraph(og?: Metadata["openGraph"]): Metadata["openGraph"] {
+  return {
+    ...defaultOpenGraph,
+    ...og,
+    images: og?.images ? og.images : defaultOpenGraph?.images,
+  };
+}
+
+export { mergeOpenGraph };

--- a/src/util/mergeMetadata.ts
+++ b/src/util/mergeMetadata.ts
@@ -1,16 +1,16 @@
 import type { Metadata } from "next";
 
 const defaultOpenGraph: Metadata["openGraph"] = {
-  type: "website",
-  // TODO: Add defaults
+	type: "website",
+	// TODO: Add defaults
 };
 
 function mergeOpenGraph(og?: Metadata["openGraph"]): Metadata["openGraph"] {
-  return {
-    ...defaultOpenGraph,
-    ...og,
-    images: og?.images ? og.images : defaultOpenGraph?.images,
-  };
+	return {
+		...defaultOpenGraph,
+		...og,
+		images: og?.images ? og.images : defaultOpenGraph?.images,
+	};
 }
 
 export { mergeOpenGraph };


### PR DESCRIPTION
Add an SEO plugin to enhance page metadata generation, enabling better search engine optimization. This includes new metadata handling functions and updates to the page structure to support SEO features.

fixes #55 
fixes #57 