### PR TITLE
feat: add IconCard component and integrate into Blocks and GridBlock

### DIFF
--- a/src/components/blocks.tsx
+++ b/src/components/blocks.tsx
@@ -1,6 +1,7 @@
 import type {
 	GridBlockType,
 	HeroBlockType,
+	IconCardType,
 	RichTextBlock,
 	StickyTitleBlock,
 } from "@/payload-types";
@@ -9,10 +10,17 @@ import { Hero } from "./hero/hero";
 import { RichText } from "./richtext/richtext";
 import { StickyTitle } from "./sticky-title/sticky-title";
 import { Grid } from "./grid/grid";
+import { IconCard } from "./icon-card/icon-card";
 
 interface BlocksProps {
 	blocks:
-		| (RichTextBlock | HeroBlockType | StickyTitleBlock | GridBlockType)[]
+		| (
+				| RichTextBlock
+				| HeroBlockType
+				| StickyTitleBlock
+				| GridBlockType
+				| IconCardType
+		  )[]
 		| null
 		| undefined;
 }
@@ -22,6 +30,7 @@ const components = {
 	"rich-text": RichText,
 	"sticky-title": StickyTitle,
 	grid: Grid,
+	"icon-card": IconCard,
 };
 
 function Blocks({ blocks }: BlocksProps) {

--- a/src/components/grid/grid.block.ts
+++ b/src/components/grid/grid.block.ts
@@ -1,5 +1,6 @@
 import type { Block } from "payload";
 import { RichTextBlock } from "../richtext/richtext.block";
+import { IconCardBlock } from "../icon-card/icon-card.block";
 
 const GridBlock: Block = {
 	slug: "grid",
@@ -15,7 +16,7 @@ const GridBlock: Block = {
 							name: "content",
 							label: "Content",
 							type: "blocks",
-							blocks: [RichTextBlock],
+							blocks: [RichTextBlock, IconCardBlock],
 						},
 					],
 				},

--- a/src/components/icon-card/icon-card.block.ts
+++ b/src/components/icon-card/icon-card.block.ts
@@ -1,0 +1,38 @@
+import { iconField } from "@/fields/icon";
+import { ParagraphFeature, lexicalEditor } from "@payloadcms/richtext-lexical";
+import type { Block } from "payload";
+
+const IconCardBlock: Block = {
+	slug: "icon-card",
+	interfaceName: "IconCardType",
+	fields: [
+		{
+			type: "tabs",
+			tabs: [
+				{
+					label: "Content",
+					fields: [
+						iconField(),
+						{
+							name: "title",
+							type: "text",
+							label: "Title",
+							required: true,
+						},
+						{
+							name: "text",
+							type: "richText",
+							label: "Text",
+							required: true,
+							editor: lexicalEditor({
+								features: [ParagraphFeature()],
+							}),
+						},
+					],
+				},
+			],
+		},
+	],
+};
+
+export { IconCardBlock };

--- a/src/components/icon-card/icon-card.module.css
+++ b/src/components/icon-card/icon-card.module.css
@@ -1,10 +1,10 @@
 .card {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  gap: var(--space-2xs);
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	gap: var(--space-2xs);
 }
 
 .text {
-  text-wrap: pretty;
+	text-wrap: pretty;
 }

--- a/src/components/icon-card/icon-card.module.css
+++ b/src/components/icon-card/icon-card.module.css
@@ -1,0 +1,10 @@
+.card {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.text {
+  text-wrap: pretty;
+}

--- a/src/components/icon-card/icon-card.tsx
+++ b/src/components/icon-card/icon-card.tsx
@@ -1,0 +1,16 @@
+import { RichText } from "@/components/richtext/richtext";
+import type { IconCardType } from "@/payload-types";
+import styles from "./icon-card.module.css";
+import { Icon } from "../icon";
+
+function IconCard(props: IconCardType) {
+	return (
+		<div className={styles.card}>
+			<Icon name={props.icon} size={64} />
+			<h3 className={styles.title}>{props.title}</h3>
+			<RichText blockType="rich-text" richText={props.text} />
+		</div>
+	);
+}
+
+export { IconCard };

--- a/src/components/icon-card/icon-card.tsx
+++ b/src/components/icon-card/icon-card.tsx
@@ -1,7 +1,7 @@
 import { RichText } from "@/components/richtext/richtext";
+import { Icon } from "../icon";
 import type { IconCardType } from "@/payload-types";
 import styles from "./icon-card.module.css";
-import { Icon } from "../icon";
 
 function IconCard(props: IconCardType) {
 	return (

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1739,7 +1739,7 @@ export interface StickyTitleBlock {
  * via the `definition` "GridBlockType".
  */
 export interface GridBlockType {
-  content?: RichTextBlock[] | null;
+  content?: (RichTextBlock | IconCardType)[] | null;
   /**
    * The number of columns to display the content in, automatically changes on tablet and mobile.
    */
@@ -1747,6 +1747,32 @@ export interface GridBlockType {
   id?: string | null;
   blockName?: string | null;
   blockType: 'grid';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "IconCardType".
+ */
+export interface IconCardType {
+  icon: Icons;
+  title: string;
+  text: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'icon-card';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1996,8 +2022,20 @@ export interface GridBlockTypeSelect<T extends boolean = true> {
     | T
     | {
         'rich-text'?: T | RichTextBlockSelect<T>;
+        'icon-card'?: T | IconCardTypeSelect<T>;
       };
   columns?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "IconCardType_select".
+ */
+export interface IconCardTypeSelect<T extends boolean = true> {
+  icon?: T;
+  title?: T;
+  text?: T;
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
Introduce the IconCard component and update Blocks and GridBlock to support it, enhancing the flexibility of content display.

fixes #31