### PR TITLE
feat: rename StickyTitleBlock to StickyTitleType

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"correctness": {
+				"noUnknownMediaFeatureName": "off"
+			}
 		}
 	},
 	"javascript": {

--- a/src/components/blocks.tsx
+++ b/src/components/blocks.tsx
@@ -2,8 +2,8 @@ import type {
 	GridBlockType,
 	HeroBlockType,
 	IconCardType,
-	RichTextBlock,
-	StickyTitleBlock,
+	RichTextType,
+	StickyTitleType,
 } from "@/payload-types";
 import type { ComponentType } from "react";
 import { Hero } from "./hero/hero";
@@ -15,9 +15,9 @@ import { IconCard } from "./icon-card/icon-card";
 interface BlocksProps {
 	blocks:
 		| (
-				| RichTextBlock
+				| RichTextType
 				| HeroBlockType
-				| StickyTitleBlock
+				| StickyTitleType
 				| GridBlockType
 				| IconCardType
 		  )[]

--- a/src/components/richtext/richtext.block.ts
+++ b/src/components/richtext/richtext.block.ts
@@ -2,7 +2,7 @@ import type { Block } from "payload";
 
 const RichTextBlock: Block = {
 	slug: "rich-text",
-	interfaceName: "RichTextBlock",
+	interfaceName: "RichTextType",
 	fields: [
 		{
 			type: "tabs",

--- a/src/components/richtext/richtext.tsx
+++ b/src/components/richtext/richtext.tsx
@@ -1,4 +1,4 @@
-import type { RichTextBlock } from "@/payload-types";
+import type { RichTextType } from "@/payload-types";
 import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
 import { RichText as RichTextLexical } from "@payloadcms/richtext-lexical/react";
 import { cva } from "class-variance-authority";
@@ -7,7 +7,7 @@ import styles from "./richtext.module.css";
 
 const RichTextLexicalStyles = cva(styles.richtext);
 
-const RichText = (props: RichTextBlock) => {
+const RichText = (props: RichTextType) => {
 	const { richText } = props;
 
 	return (

--- a/src/components/sticky-title/sticky-title.block.ts
+++ b/src/components/sticky-title/sticky-title.block.ts
@@ -4,7 +4,7 @@ import { GridBlock } from "../grid/grid.block";
 
 const StickyTitleBlock: Block = {
 	slug: "sticky-title",
-	interfaceName: "StickyTitleBlock",
+	interfaceName: "StickyTitleType",
 	fields: [
 		{
 			type: "tabs",

--- a/src/components/sticky-title/sticky-title.tsx
+++ b/src/components/sticky-title/sticky-title.tsx
@@ -1,11 +1,11 @@
 import { Blocks } from "@/components/blocks";
-import type { StickyTitleBlock } from "@/payload-types";
+import type { StickyTitleType } from "@/payload-types";
 import { cva } from "class-variance-authority";
 import styles from "./sticky-title.module.css";
 
 const stickyTitleStyles = cva(styles.container);
 
-function StickyTitle(props: StickyTitleBlock) {
+function StickyTitle(props: StickyTitleType) {
 	return (
 		<section className={stickyTitleStyles()}>
 			<div>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1653,7 +1653,7 @@ export interface Page {
   title: string;
   slug: string;
   content?: {
-    blocks?: (HeroBlockType | RichTextBlock | StickyTitleBlock | GridBlockType)[] | null;
+    blocks?: (HeroBlockType | RichTextType | StickyTitleType | GridBlockType)[] | null;
   };
   seo?: {
     title?: string | null;
@@ -1701,9 +1701,9 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "RichTextBlock".
+ * via the `definition` "RichTextType".
  */
-export interface RichTextBlock {
+export interface RichTextType {
   richText?: {
     root: {
       type: string;
@@ -1725,11 +1725,11 @@ export interface RichTextBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "StickyTitleBlock".
+ * via the `definition` "StickyTitleType".
  */
-export interface StickyTitleBlock {
+export interface StickyTitleType {
   title: string;
-  blocks?: (RichTextBlock | GridBlockType)[] | null;
+  blocks?: (RichTextType | GridBlockType)[] | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'sticky-title';
@@ -1739,7 +1739,7 @@ export interface StickyTitleBlock {
  * via the `definition` "GridBlockType".
  */
 export interface GridBlockType {
-  content?: (RichTextBlock | IconCardType)[] | null;
+  content?: (RichTextType | IconCardType)[] | null;
   /**
    * The number of columns to display the content in, automatically changes on tablet and mobile.
    */
@@ -1962,8 +1962,8 @@ export interface PagesSelect<T extends boolean = true> {
           | T
           | {
               hero?: T | HeroBlockTypeSelect<T>;
-              'rich-text'?: T | RichTextBlockSelect<T>;
-              'sticky-title'?: T | StickyTitleBlockSelect<T>;
+              'rich-text'?: T | RichTextTypeSelect<T>;
+              'sticky-title'?: T | StickyTitleTypeSelect<T>;
               grid?: T | GridBlockTypeSelect<T>;
             };
       };
@@ -1991,23 +1991,23 @@ export interface HeroBlockTypeSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "RichTextBlock_select".
+ * via the `definition` "RichTextType_select".
  */
-export interface RichTextBlockSelect<T extends boolean = true> {
+export interface RichTextTypeSelect<T extends boolean = true> {
   richText?: T;
   id?: T;
   blockName?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "StickyTitleBlock_select".
+ * via the `definition` "StickyTitleType_select".
  */
-export interface StickyTitleBlockSelect<T extends boolean = true> {
+export interface StickyTitleTypeSelect<T extends boolean = true> {
   title?: T;
   blocks?:
     | T
     | {
-        'rich-text'?: T | RichTextBlockSelect<T>;
+        'rich-text'?: T | RichTextTypeSelect<T>;
         grid?: T | GridBlockTypeSelect<T>;
       };
   id?: T;
@@ -2021,7 +2021,7 @@ export interface GridBlockTypeSelect<T extends boolean = true> {
   content?:
     | T
     | {
-        'rich-text'?: T | RichTextBlockSelect<T>;
+        'rich-text'?: T | RichTextTypeSelect<T>;
         'icon-card'?: T | IconCardTypeSelect<T>;
       };
   columns?: T;


### PR DESCRIPTION
Update the naming of StickyTitleBlock to StickyTitleType for consistency and clarity across the codebase. This change addresses issue fixes #63.