### PR TITLE
fix: update type alias for PageProps in PageTemplate

### DIFF
--- a/src/app/(frontend)/(pages)/[slug]/page.tsx
+++ b/src/app/(frontend)/(pages)/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { Blocks } from "@/components/blocks";
-import type { Page } from "@/payload-types";
+import type { Page as PageProps } from "@/payload-types";
 
-function PageTemplate(props: Page) {
+function PageTemplate(props: PageProps) {
 	return <Blocks blocks={props.content?.blocks} />;
 }
 


### PR DESCRIPTION
Change the type alias for the PageProps in the PageTemplate component to improve clarity and consistency.

fixes #77