### PR TITLE
feat: extend global settings with additional options

### DIFF
--- a/src/app/(frontend)/(pages)/layout.tsx
+++ b/src/app/(frontend)/(pages)/layout.tsx
@@ -1,15 +1,10 @@
 import { Footer } from "@/patterns/Footer/Footer";
 import { Navigation } from "@/patterns/Navigation/Navigation";
-import type { Metadata } from "next";
+
 import type React from "react";
 
 import "@/styles/globals.css";
 import "@fontsource-variable/national-park";
-
-export const metadata: Metadata = {
-	description: "",
-	title: "Patrick Roelofs",
-};
 
 export default async function RootLayout(props: { children: React.ReactNode }) {
 	const { children } = props;

--- a/src/collections/Settings.ts
+++ b/src/collections/Settings.ts
@@ -44,7 +44,7 @@ export const Settings: GlobalConfig = {
 					],
 				},
 				{
-					label: "Footer",
+					label: "Social Media",
 					fields: [
 						{
 							name: "socials",
@@ -65,6 +65,35 @@ export const Settings: GlobalConfig = {
 									],
 								},
 							],
+						},
+					],
+				},
+				{
+					name: "metadata",
+					label: "Metadata",
+					fields: [
+						{
+							name: "siteName",
+							type: "text",
+							label: "Site Name",
+							defaultValue: "My Site",
+							required: true,
+						},
+						{
+							name: "siteDescription",
+							type: "text",
+							label: "Site Description",
+							defaultValue: "A great site built with Payload",
+							required: true,
+						},
+						{
+							name: "siteThemeColor",
+							type: "text",
+							label: "Site Theme Color",
+							required: false,
+							admin: {
+								description: "Used for browser theme color",
+							},
 						},
 					],
 				},

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2074,6 +2074,14 @@ export interface Setting {
     link: string;
     id?: string | null;
   }[];
+  metadata: {
+    siteName: string;
+    siteDescription: string;
+    /**
+     * Used for browser theme color
+     */
+    siteThemeColor?: string | null;
+  };
   _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -2098,6 +2106,13 @@ export interface SettingsSelect<T extends boolean = true> {
         icon?: T;
         link?: T;
         id?: T;
+      };
+  metadata?:
+    | T
+    | {
+        siteName?: T;
+        siteDescription?: T;
+        siteThemeColor?: T;
       };
   _status?: T;
   updatedAt?: T;

--- a/src/util/generateMetadata.ts
+++ b/src/util/generateMetadata.ts
@@ -42,8 +42,8 @@ async function generateMeta(args: {
 		title: `${doc.seo?.title} | ${metadata.siteName}`,
 		description: doc.seo?.description || metadata.siteDescription,
 		openGraph: mergeOpenGraph({
-			// title,
-			// description,
+			title: `${doc.seo?.title} | ${metadata.siteName}`,
+			description: doc.seo?.description || metadata.siteDescription,
 			images: ogImage ? [{ url: ogImage }] : [],
 			url,
 		}),

--- a/src/util/generateMetadata.ts
+++ b/src/util/generateMetadata.ts
@@ -2,6 +2,7 @@ import type { Config, Media, Page } from "@/payload-types";
 import type { Metadata } from "next";
 import { getServersideURL } from "./getServersideURL";
 import { mergeOpenGraph } from "./mergeMetadata";
+import { payload } from "./getPayloadConfig";
 
 function getImageURL(
 	image?: Media | Config["db"]["defaultIDType"] | null,
@@ -25,24 +26,25 @@ async function generateMeta(args: {
 	doc: Partial<Page>;
 	collection: "pages";
 }): Promise<Metadata> {
+	const { metadata } = await payload.findGlobal({
+		slug: "settings",
+	});
+
 	const { doc } = args || {};
 
-	// TODO: Implement SEO
-	// const ogImage = getImageURL(doc.meta?.image);
-	// const title = doc.meta?.title || "";
-	// const description = doc.meta?.description || "";
+	const ogImage = getImageURL(doc.seo?.image);
 
 	const slug = doc.slug === "home" ? "" : `/${doc.slug}`;
 	const collection = args.collection === "pages" ? "" : `/${args.collection}`;
 	const url = `${getServersideURL()}${collection}${slug}`;
 
 	return {
-		// title,
-		// description,
+		title: `${doc.seo?.title} | ${metadata.siteName}`,
+		description: doc.seo?.description || metadata.siteDescription,
 		openGraph: mergeOpenGraph({
 			// title,
 			// description,
-			// images: ogImage ? [{ url: ogImage }] : [],
+			images: ogImage ? [{ url: ogImage }] : [],
 			url,
 		}),
 		alternates: {


### PR DESCRIPTION
Enhance global settings by introducing new metadata fields, including site name, site description, and site theme color. This update improves configuration flexibility and allows for better site representation.

Fixes #111